### PR TITLE
Fix: Disable background animation to improve performance

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -175,7 +175,7 @@
     background-position: 0 0, 30px 30px;
     pointer-events: none;
     z-index: -1;
-    animation: shimmer 20s ease-in-out infinite;
+    /* animation: shimmer 20s ease-in-out infinite; */
   }
 
   /* Light mode geometric pattern */
@@ -183,7 +183,7 @@
     background-image: 
       linear-gradient(45deg, transparent 48%, rgba(34, 211, 238, 0.025) 49%, rgba(34, 211, 238, 0.025) 51%, transparent 52%),
       linear-gradient(-45deg, transparent 48%, rgba(59, 130, 246, 0.025) 49%, rgba(59, 130, 246, 0.025) 51%, transparent 52%);
-    animation: shimmer-light 25s ease-in-out infinite;
+    /* animation: shimmer-light 25s ease-in-out infinite; */
   }
 
   /* Glass panel styles */
@@ -288,7 +288,7 @@
   }
 
   /* Shimmer animation for background */
-  @keyframes shimmer {
+  /* @keyframes shimmer {
     0%, 100% {
       opacity: 1;
       transform: translateX(0) translateY(0);
@@ -305,10 +305,10 @@
       opacity: 0.8;
       transform: translateX(5px) translateY(-10px);
     }
-  }
+  } */
 
   /* Light mode shimmer animation */
-  @keyframes shimmer-light {
+  /* @keyframes shimmer-light {
     0%, 100% {
       opacity: 0.7;
       transform: translateX(0) translateY(0);
@@ -325,7 +325,7 @@
       opacity: 0.6;
       transform: translateX(-10px) translateY(5px);
     }
-  }
+  } */
 
   /* Glow animation for neon elements */
   @keyframes neon-glow {


### PR DESCRIPTION
The animated background, defined in app/globals.css, was identified as a potential cause of high CPU/GPU usage, which could be perceived by you as network slowness or general unresponsiveness.

This commit disables the animation by:
- Commenting out the 'animation' property in the 'body::before' and '.light body::before' CSS rules.
- Commenting out the '@keyframes shimmer' and '@keyframes shimmer-light' definitions as they are no longer used.

This change addresses your feedback regarding performance concerns (originally reported as high network usage in issue 15).