### PR TITLE
Fix: Resolve non-spinning loader animation

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -275,11 +275,11 @@
   }
 
   /* Smooth theme transition wrapper */
-  * {
+  /* * {
     transition: background-color 0.5s cubic-bezier(0.4, 0, 0.2, 1), 
                 border-color 0.5s cubic-bezier(0.4, 0, 0.2, 1),
                 color 0.5s cubic-bezier(0.4, 0, 0.2, 1);
-  }
+  } */
 
   /* Smooth scrolling */
   html {


### PR DESCRIPTION
The global CSS transition rule (`* { transition: ... }`) in `app/globals.css` was identified as the cause of the `animate-spin` utility class not working for the `Loader2` component. This global rule interfered with the `transform` property used by the spin animation.

The fix involves commenting out the overly broad global transition. Specific components, such as the theme toggle, already implement their own transition classes, so no visual regressions are expected from this change. The spinner is now expected to animate correctly.